### PR TITLE
add: model filepath

### DIFF
--- a/chaine/api.py
+++ b/chaine/api.py
@@ -9,7 +9,9 @@ from chaine.crf import Model, Trainer
 from chaine.typing import Dataset, Labels
 
 
-def train(dataset: Dataset, labels: Labels, **kwargs) -> Model:
+def train(
+    dataset: Dataset, labels: Labels, model_filepath: str = "model.crf", **kwargs
+) -> Model:
     """Train a conditional random field
 
     Parameters
@@ -18,6 +20,8 @@ def train(dataset: Dataset, labels: Labels, **kwargs) -> Model:
         Dataset consisting of sequences of feature sets
     labels : Labels
         Labels corresponding to each instance in the dataset
+    model_filepath : str
+        Path to model location
     algorithm : str
         Following algorithms are available:
             * lbfgs: Limited-memory BFGS with L1/L2 regularization
@@ -144,7 +148,7 @@ def train(dataset: Dataset, labels: Labels, **kwargs) -> Model:
     """
     # initialize trainer and start training
     trainer = Trainer(**kwargs)
-    trainer.train(dataset, labels, "model.crf")
+    trainer.train(dataset, labels, model_filepath=model_filepath)
 
     # load and return the trained model
-    return Model("model.crf")
+    return Model(model_filepath)


### PR DESCRIPTION
Adding the `model_filepath` argument to the `train`-Function in `api.py` so that the model can be saved easier in different locations.